### PR TITLE
Preserve z coordinate in h2geodb (init WKBWriter with three dimensions)

### DIFF
--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/h2geodb/WKB.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/h2geodb/WKB.java
@@ -59,7 +59,7 @@ class WKB {
 
 
 	static byte[] toWKB(Geometry jtsGeom) {
-		WKBWriter writer = new WKBWriter(2, true);
+		WKBWriter writer = new WKBWriter(3, true);
 		return writer.write(jtsGeom);
 	}
 }


### PR DESCRIPTION
Hi Karel, this pull request just changes the WKBWriter initialization in h2geodb's WKB class to use three dimensions instead of two. Previously z coordinates were not preserved when writing JTS geometries to WKB. After this patch, z coordinates survive round trip serialization to WKB. All tests still pass. Do you see any problem with merging this change?
