### PR TITLE
Cast and return object in geodb toJTS if its already a Geometry

### DIFF
--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/h2geodb/GeoDBValueExtractor.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/h2geodb/GeoDBValueExtractor.java
@@ -57,6 +57,9 @@ public class GeoDBValueExtractor<X> extends AbstractJTSGeometryValueExtractor<X>
 		if ( object == null ) {
 			return null;
 		}
+		if ( object instanceof Geometry ) {
+		    return (Geometry) object;
+		}
 		try {
 			if ( object instanceof Blob ) {
 				return geometryFromByteArray( toByteArray( (Blob) object ) );


### PR DESCRIPTION
While running some jUnit tests in a project that use an in-memory h2/geodb for testing, I ran into a situation where the object being passed to toJTS was already a Geometry. I'm not totally sure why this was happening (caching by h2?), but it seems logical to just cast and return the object if it's already a geometry. It might even make sense to put this in AbstractJTSGeometryValueExtractor as it seems applicable regardless of the provider.

At least one other person has run into this, although I'm not sure if they were using h2:

http://stackoverflow.com/questions/20214105/hibernate-spatial-illegal-argument-exception
